### PR TITLE
ajout des tests unitaires manquants (métiers, entités, carte)

### DIFF
--- a/ARCHITECTURE_MODULES.md
+++ b/ARCHITECTURE_MODULES.md
@@ -18,7 +18,9 @@ fichier .java de la classe.
 	- EtiquettesOuvriers.java
 	- GestionCollisions.java
     - GestionInput.java
+	- Launcher.java
     - Main.java
+	- RenduBatiments.java
     - RenduCarte.java
 	- RenduMonde.java
 	- RenduOuvriers.java
@@ -26,9 +28,14 @@ fichier .java de la classe.
 - package batiments :
     - Batiment.java
     - CentreLancement.java
+	- CentreRecherche.java
+	- Ecole.java
+	- Entrepot.java
     - Hopital.java
     - LieuDeRessource.java
     - Maison.java
+	- Serre.java
+	- StationPompage.java
 	- TypeBatiment.java
     - Usine.java
 
@@ -88,22 +95,42 @@ fichier .java de la classe.
 - package ressources:
     - Recette.java
     - RegistreRecettes.java
+	- Ressources.java
     - Stock.java
     - TypeRessource.java
 
 ### Packages de test dans src/test/java :    
 
 - package batiments :
-    - TestCentreLancement.java
+	- TestCentreLancementComplet.java
+    - TestCentreRecherche.java
+	- TestEcole.java
+	- TestEntrepot.java
     - TestHopital.java
     - TestLieuDeRessource.java
     - TestMaison.java
+	- TestSerre.java
+	- TestStationPompage.java
     - TestUsine.java
-    
+	- TestUsineComplet.java
+
+- package carte
+	- TestCase.java
+	- TestDirection.java
+
+- package entites
+	- TestJoueur.java
+	- TestOuvrier.java
 
 - package fusee :
-    - TestFusee.java
+    - TestFuseeComplet.java
     - TestModuleFusee.java
+
+- package metiers
+	- TestBucheron.java
+	- TestIngenieur.java
+	- TestMacon.java
+	- TestTechnicien.java
 
 - package ressources :
     - StockTest.java

--- a/src/test/java/batiments/TestEcole.java
+++ b/src/test/java/batiments/TestEcole.java
@@ -1,0 +1,145 @@
+package batiments;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import entites.Ouvrier;
+import entites.Role;
+import metiers.Metier;
+import ressources.Stock;
+
+public class TestEcole {
+
+    private Ecole ecole;
+    private Ouvrier chercheur;
+    private Ouvrier ouvrierSansMétier;
+
+    /** Métier factice avec nom "Chercheur" (attendu par Ecole.mettreAJour). */
+    private static Metier metierChercheur() {
+        return new Metier() {
+            @Override public Role getType()                                    { return Role.SCIENTIFIQUE; }
+            @Override public boolean peutTravaillerDans(Batiment b)            { return b.getType() == TypeBatiment.ECOLE; }
+            @Override public void travailler(Ouvrier o, Batiment b, Stock s, int t) {}
+            @Override public String getNomAffichage()                          { return "Chercheur"; }
+        };
+    }
+
+    @Before
+    public void setUp() {
+        // École avec progressionRecherche = 0.5
+        ecole           = new Ecole("École Centrale", 5, 5, 0.5f);
+        chercheur       = new Ouvrier("Einstein", 0, 0);
+        ouvrierSansMétier = new Ouvrier("Rookie", 0, 0);
+        chercheur.setMetier(metierChercheur());
+    }
+
+    // ================================================================== //
+    //  1. TYPE DE BÂTIMENT                                                //
+    // ================================================================== //
+
+    @Test
+    public void testTypeBatiment() {
+        assertEquals("Le type doit être ECOLE", TypeBatiment.ECOLE, ecole.getType());
+    }
+
+    // ================================================================== //
+    //  2. GESTION DU PERSONNEL                                            //
+    // ================================================================== //
+
+    @Test
+    public void testAffecterPersonnel_ajoute() {
+        ecole.affecterPersonnel(chercheur);
+        assertEquals("L'ouvrier doit être affecté à l'école", ecole, chercheur.getPosteActuel());
+    }
+
+    @Test
+    public void testAffecterPersonnel_pasDeDoblon() {
+        ecole.affecterPersonnel(chercheur);
+        ecole.affecterPersonnel(chercheur);
+        // Capacité max = 5 ; si doublon ajouté, place < 4 au lieu de 4
+        // On ajoute 4 autres ouvriers : si le chercheur compte 2 fois, la 5e place est prise
+        for (int i = 0; i < 4; i++) ecole.affecterPersonnel(new Ouvrier("Eleve" + i, 0, 0));
+        assertFalse("Avec le chercheur + 4 autres, l'école doit être pleine", ecole.aDeLaPlace());
+    }
+
+    @Test
+    public void testRetirerPersonnel_liberePlace() {
+        ecole.affecterPersonnel(chercheur);
+        ecole.retirerPersonnel(chercheur);
+        assertNull("Le poste doit être libéré", chercheur.getPosteActuel());
+        assertTrue("L'école doit à nouveau avoir de la place", ecole.aDeLaPlace());
+    }
+
+    @Test
+    public void testADeLaPlace_capaciteMaxAtteinte() {
+        for (int i = 0; i < 5; i++) {
+            ecole.affecterPersonnel(new Ouvrier("Eleve" + i, 0, 0));
+        }
+        assertFalse("L'école doit être pleine à 5 élèves (capacité max)", ecole.aDeLaPlace());
+    }
+
+    @Test
+    public void testADeLaPlace_vide() {
+        assertTrue("L'école vide doit avoir de la place", ecole.aDeLaPlace());
+    }
+
+    // ================================================================== //
+    //  3. OPÉRATIONALITÉ                                                  //
+    // ================================================================== //
+
+    @Test
+    public void testIsOperationnel_toujours() {
+        assertTrue("L'école doit toujours être opérationnelle", ecole.isOperationnel());
+    }
+
+    // ================================================================== //
+    //  4. MISE À JOUR — expérience chercheur                              //
+    // ================================================================== //
+
+    @Test
+    public void testMettreAJour_chercheurGagneExperience() {
+        ecole.affecterPersonnel(chercheur);
+        // 600 ticks * (1.0 + 0.5 progressionRecherche) = 900 ticks → dépasse le seuil DEBUTANT (600)
+        ecole.mettreAJour(null, 600);
+        assertNotEquals("Le chercheur doit avoir progressé au-delà du niveau DEBUTANT",
+                Ouvrier.NiveauExp.DEBUTANT, chercheur.getNiveau());
+    }
+
+    @Test
+    public void testMettreAJour_ouvrierSansMetier_sansEffet() {
+        ecole.affecterPersonnel(ouvrierSansMétier);
+        Ouvrier.NiveauExp niveauAvant = ouvrierSansMétier.getNiveau();
+        ecole.mettreAJour(null, 10_000);
+        assertEquals("Un ouvrier sans métier ne doit pas progresser",
+                niveauAvant, ouvrierSansMétier.getNiveau());
+    }
+
+    @Test
+    public void testMettreAJour_sansEleve_aucunEffet() {
+        // Pas d'élève → ne doit pas planter
+        ecole.mettreAJour(null, 500);
+    }
+
+    // ================================================================== //
+    //  5. POSITION & NOM                                                  //
+    // ================================================================== //
+
+    @Test
+    public void testGetNom() {
+        assertEquals("École Centrale", ecole.getNom());
+    }
+
+    @Test
+    public void testGetPosition() {
+        assertEquals(5, ecole.getX());
+        assertEquals(5, ecole.getY());
+    }
+
+    @Test
+    public void testDeplacer() {
+        ecole.deplacer(10, 20);
+        assertEquals(10, ecole.getX());
+        assertEquals(20, ecole.getY());
+    }
+}

--- a/src/test/java/batiments/TestSerre.java
+++ b/src/test/java/batiments/TestSerre.java
@@ -1,0 +1,128 @@
+package batiments;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import ressources.Ressource;
+import ressources.Stock;
+import ressources.TypeRessource;
+
+public class TestSerre {
+
+    private Serre serre;
+    private Stock stock;
+
+    @Before
+    public void setUp() throws Exception {
+        // Serre avec rendement de 10 unités de nourriture
+        serre = new Serre("Serre Alpha", 3, 7, 10);
+        stock = new Stock(false); // mode facile (pas de contrainte globale)
+    }
+
+    // ================================================================== //
+    //  1. TYPE DE BÂTIMENT                                                //
+    // ================================================================== //
+
+    @Test
+    public void testTypeBatiment() {
+        assertEquals("Le type doit être SERRE", TypeBatiment.SERRE, serre.getType());
+    }
+
+    // ================================================================== //
+    //  2. OPÉRATIONALITÉ                                                  //
+    // ================================================================== //
+
+    @Test
+    public void testIsOperationnel_toujours() {
+        assertTrue("La serre doit toujours être opérationnelle", serre.isOperationnel());
+    }
+
+    // ================================================================== //
+    //  3. RÉCOLTE MANUELLE (recolter)                                     //
+    // ================================================================== //
+
+    @Test
+    public void testRecolter_retourneNourritureAvecBonRendement() {
+        Ressource r = serre.recolter();
+        assertNotNull("recolter() ne doit pas retourner null", r);
+        assertEquals("Le type doit être NOURRITURE", TypeRessource.NOURRITURE, r.getType());
+        assertEquals("La quantité doit correspondre au rendement", 10, r.getQuantite());
+    }
+
+    // ================================================================== //
+    //  4. MISE À JOUR — production automatique (mettreAJour)              //
+    // ================================================================== //
+
+    @Test
+    public void testMettreAJour_progresseCycle() {
+        // TEMPS_POUSSE_SEC = 60. Après 30s, progression = 50%
+        double progresBefore = serre.getProgresPousse();
+        serre.mettreAJour(stock, 30);
+        assertTrue("Le progrès doit avoir augmenté",
+                serre.getProgresPousse() > progresBefore);
+    }
+
+    @Test
+    public void testMettreAJour_cycleComplet_ajouteAuStock() throws Exception {
+        // 60 secondes = un cycle complet → nourriture ajoutée au stock
+        serre.mettreAJour(stock, 60);
+        assertEquals("La nourriture doit être dans le stock après 60s",
+                10, stock.getQuantite(TypeRessource.NOURRITURE));
+    }
+
+    @Test
+    public void testMettreAJour_apresRecolte_progresReset() {
+        // Après un cycle, le progrès repart à 0
+        serre.mettreAJour(stock, 60);
+        assertEquals("Le progrès doit être remis à 0 après récolte",
+                0.0, serre.getProgresPousse(), 0.01);
+    }
+
+    @Test
+    public void testMettreAJour_deuxCycles_stokDoublé() throws Exception {
+        serre.mettreAJour(stock, 60); // cycle 1
+        serre.mettreAJour(stock, 60); // cycle 2
+        assertEquals("Deux cycles doivent produire 2× le rendement",
+                20, stock.getQuantite(TypeRessource.NOURRITURE));
+    }
+
+    @Test
+    public void testMettreAJour_cyclePasEncore_stockInchange() throws Exception {
+        // Moins d'un cycle : pas encore de nourriture
+        serre.mettreAJour(stock, 30);
+        assertEquals("Pas de nourriture avant la fin d'un cycle",
+                0, stock.getQuantite(TypeRessource.NOURRITURE));
+    }
+
+    // ================================================================== //
+    //  5. GESTION DU PERSONNEL (stub — la serre ne gère pas de personnel) //
+    // ================================================================== //
+
+    @Test
+    public void testADeLaPlace_toujours() {
+        assertTrue("La serre doit toujours avoir de la place", serre.aDeLaPlace());
+    }
+
+    // ================================================================== //
+    //  6. POSITION & NOM                                                  //
+    // ================================================================== //
+
+    @Test
+    public void testGetNom() {
+        assertEquals("Serre Alpha", serre.getNom());
+    }
+
+    @Test
+    public void testGetPosition() {
+        assertEquals(3, serre.getX());
+        assertEquals(7, serre.getY());
+    }
+
+    @Test
+    public void testDeplacer() {
+        serre.deplacer(1, 2);
+        assertEquals(1, serre.getX());
+        assertEquals(2, serre.getY());
+    }
+}

--- a/src/test/java/batiments/TestStationPompage.java
+++ b/src/test/java/batiments/TestStationPompage.java
@@ -1,0 +1,126 @@
+package batiments;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import ressources.Ressource;
+import ressources.Stock;
+import ressources.TypeRessource;
+
+public class TestStationPompage {
+
+    private StationPompage station;
+    private Stock stock;
+
+    @Before
+    public void setUp() throws Exception {
+        // Débit de 5 unités d'eau par pompage
+        station = new StationPompage("Station Bêta", 2, 8, 5);
+        stock   = new Stock(false); // mode facile
+    }
+
+    // ================================================================== //
+    //  1. TYPE DE BÂTIMENT                                                //
+    // ================================================================== //
+
+    @Test
+    public void testTypeBatiment() {
+        assertEquals("Le type doit être STATION_POMPAGE",
+                TypeBatiment.STATION_POMPAGE, station.getType());
+    }
+
+    // ================================================================== //
+    //  2. OPÉRATIONALITÉ                                                  //
+    // ================================================================== //
+
+    @Test
+    public void testIsOperationnel_toujours() {
+        assertTrue("La station doit toujours être opérationnelle", station.isOperationnel());
+    }
+
+    // ================================================================== //
+    //  3. POMPAGE MANUEL (pomper)                                         //
+    // ================================================================== //
+
+    @Test
+    public void testPomper_retourneEauAvecBonDebit() {
+        Ressource r = station.pomper();
+        assertNotNull("pomper() ne doit pas retourner null", r);
+        assertEquals("Le type doit être EAU", TypeRessource.EAU, r.getType());
+        assertEquals("La quantité doit correspondre au débit", 5, r.getQuantite());
+    }
+
+    @Test
+    public void testGetDebitEau() {
+        assertEquals("Le débit renvoyé doit être 5", 5, station.getDebitEau());
+    }
+
+    // ================================================================== //
+    //  4. MISE À JOUR — pompage automatique (mettreAJour)                 //
+    // ================================================================== //
+
+    @Test
+    public void testMettreAJour_pasDEauAvantIntervalle() throws Exception {
+        // INTERVALLE_POMPAGE_SEC = 10 ; après 5 s, pas encore de pompage
+        station.mettreAJour(stock, 5);
+        assertEquals("Pas d'eau avant l'intervalle de 10 secondes",
+                0, stock.getQuantite(TypeRessource.EAU));
+    }
+
+    @Test
+    public void testMettreAJour_exactementIntervalle_ajouteEau() throws Exception {
+        station.mettreAJour(stock, 10);
+        assertEquals("Un pompage doit avoir eu lieu à 10 secondes",
+                5, stock.getQuantite(TypeRessource.EAU));
+    }
+
+    @Test
+    public void testMettreAJour_deuxIntervalles_eauDoublee() throws Exception {
+        station.mettreAJour(stock, 10); // premier pompage
+        station.mettreAJour(stock, 10); // second pompage
+        assertEquals("Deux pumpings doivent produire 2× le débit",
+                10, stock.getQuantite(TypeRessource.EAU));
+    }
+
+    @Test
+    public void testMettreAJour_tempsAccumule_pumpingDecale() throws Exception {
+        // 7s puis 5s → total 12s → devrait pomper une fois
+        station.mettreAJour(stock, 7);
+        assertEquals("Pas encore de pompage après 7s", 0, stock.getQuantite(TypeRessource.EAU));
+        station.mettreAJour(stock, 5);
+        assertEquals("Un pompage doit avoir eu lieu après 12s cumulées",
+                5, stock.getQuantite(TypeRessource.EAU));
+    }
+
+    // ================================================================== //
+    //  5. GESTION DU PERSONNEL (stub — la station n'en a pas)            //
+    // ================================================================== //
+
+    @Test
+    public void testADeLaPlace_toujours() {
+        assertTrue("La station doit toujours avoir de la place", station.aDeLaPlace());
+    }
+
+    // ================================================================== //
+    //  6. POSITION & NOM                                                  //
+    // ================================================================== //
+
+    @Test
+    public void testGetNom() {
+        assertEquals("Station Bêta", station.getNom());
+    }
+
+    @Test
+    public void testGetPosition() {
+        assertEquals(2, station.getX());
+        assertEquals(8, station.getY());
+    }
+
+    @Test
+    public void testDeplacer() {
+        station.deplacer(0, 0);
+        assertEquals(0, station.getX());
+        assertEquals(0, station.getY());
+    }
+}

--- a/src/test/java/carte/TestCase.java
+++ b/src/test/java/carte/TestCase.java
@@ -1,0 +1,106 @@
+package carte;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import entites.Ouvrier;
+
+public class TestCase {
+
+    private Case caseVide;
+    private Ouvrier ouvrier1;
+    private Ouvrier ouvrier2;
+
+    @Before
+    public void setUp() {
+        caseVide = new Case();
+        ouvrier1 = new Ouvrier("Alice", 0, 0);
+        ouvrier2 = new Ouvrier("Bob",   0, 0);
+    }
+
+    // ================================================================== //
+    //  1. INITIALISATION                                                  //
+    // ================================================================== //
+
+    @Test
+    public void init_caseVide_pasOccupee() {
+        assertFalse("Une case fraîchement créée ne doit pas être occupée",
+                caseVide.estOccupee());
+    }
+
+    @Test
+    public void init_contenuVide() {
+        assertTrue("Le contenu initial doit être vide", caseVide.getContenu().isEmpty());
+    }
+
+    // ================================================================== //
+    //  2. AJOUTER                                                         //
+    // ================================================================== //
+
+    @Test
+    public void ajouter_unItem_caseEstOccupee() {
+        caseVide.ajouter(ouvrier1);
+        assertTrue(caseVide.estOccupee());
+    }
+
+    @Test
+    public void ajouter_unItem_contenuContientItem() {
+        caseVide.ajouter(ouvrier1);
+        assertTrue(caseVide.getContenu().contains(ouvrier1));
+    }
+
+    @Test
+    public void ajouter_deuxItems_contenuContientLesDeux() {
+        caseVide.ajouter(ouvrier1);
+        caseVide.ajouter(ouvrier2);
+        assertTrue(caseVide.getContenu().contains(ouvrier1));
+        assertTrue(caseVide.getContenu().contains(ouvrier2));
+        assertEquals(2, caseVide.getContenu().size());
+    }
+
+    @Test
+    public void ajouter_null_ignoreSansCrash() {
+        caseVide.ajouter(null); // ne doit pas lever d'exception
+        assertFalse("Un null ne doit pas rendre la case occupée", caseVide.estOccupee());
+    }
+
+    // ================================================================== //
+    //  3. SUPPRIMER                                                       //
+    // ================================================================== //
+
+    @Test
+    public void supprimer_itemPresent_videCase() {
+        caseVide.ajouter(ouvrier1);
+        caseVide.supprimer(ouvrier1);
+        assertFalse(caseVide.estOccupee());
+    }
+
+    @Test
+    public void supprimer_unParmiDeux_lautreReste() {
+        caseVide.ajouter(ouvrier1);
+        caseVide.ajouter(ouvrier2);
+        caseVide.supprimer(ouvrier1);
+        assertFalse(caseVide.getContenu().contains(ouvrier1));
+        assertTrue(caseVide.getContenu().contains(ouvrier2));
+    }
+
+    @Test
+    public void supprimer_itemAbsent_pasDeException() {
+        caseVide.supprimer(ouvrier1); // ne doit pas lever d'exception
+        assertFalse(caseVide.estOccupee());
+    }
+
+    // ================================================================== //
+    //  4. IMMUTABILITÉ DU CONTENU RETOURNÉ                                //
+    // ================================================================== //
+
+    @Test
+    public void getContenu_retourneCopie_pasLaListeInterne() {
+        caseVide.ajouter(ouvrier1);
+        // Modifier la liste retournée ne doit pas affecter la case
+        caseVide.getContenu().clear();
+        assertTrue("La modification de la liste retournée ne doit pas vider la case",
+                caseVide.estOccupee());
+    }
+}

--- a/src/test/java/carte/TestDirection.java
+++ b/src/test/java/carte/TestDirection.java
@@ -1,0 +1,83 @@
+package carte;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class TestDirection {
+
+    // ================================================================== //
+    //  1. DELTAS CARDINAUX                                                //
+    // ================================================================== //
+
+    @Test
+    public void nord_dx0_dyMoins1_dz0() {
+        assertEquals( 0, Direction.NORD.getDx());
+        assertEquals(-1, Direction.NORD.getDy());
+        assertEquals( 0, Direction.NORD.getDz());
+    }
+
+    @Test
+    public void sud_dx0_dyPlus1_dz0() {
+        assertEquals( 0, Direction.SUD.getDx());
+        assertEquals( 1, Direction.SUD.getDy());
+        assertEquals( 0, Direction.SUD.getDz());
+    }
+
+    @Test
+    public void est_dxPlus1_dy0_dz0() {
+        assertEquals( 1, Direction.EST.getDx());
+        assertEquals( 0, Direction.EST.getDy());
+        assertEquals( 0, Direction.EST.getDz());
+    }
+
+    @Test
+    public void ouest_dxMoins1_dy0_dz0() {
+        assertEquals(-1, Direction.OUEST.getDx());
+        assertEquals( 0, Direction.OUEST.getDy());
+        assertEquals( 0, Direction.OUEST.getDz());
+    }
+
+    @Test
+    public void haut_dx0_dy0_dzPlus1() {
+        assertEquals( 0, Direction.HAUT.getDx());
+        assertEquals( 0, Direction.HAUT.getDy());
+        assertEquals( 1, Direction.HAUT.getDz());
+    }
+
+    @Test
+    public void bas_dx0_dy0_dzMoins1() {
+        assertEquals( 0, Direction.BAS.getDx());
+        assertEquals( 0, Direction.BAS.getDy());
+        assertEquals(-1, Direction.BAS.getDz());
+    }
+
+    // ================================================================== //
+    //  2. OPPOSÉS COHÉRENTS                                               //
+    // ================================================================== //
+
+    @Test
+    public void nord_et_sud_opposes() {
+        assertEquals(0, Direction.NORD.getDx() + Direction.SUD.getDx());
+        assertEquals(0, Direction.NORD.getDy() + Direction.SUD.getDy());
+    }
+
+    @Test
+    public void est_et_ouest_opposes() {
+        assertEquals(0, Direction.EST.getDx() + Direction.OUEST.getDx());
+        assertEquals(0, Direction.EST.getDy() + Direction.OUEST.getDy());
+    }
+
+    @Test
+    public void haut_et_bas_opposes() {
+        assertEquals(0, Direction.HAUT.getDz() + Direction.BAS.getDz());
+    }
+
+    // ================================================================== //
+    //  3. NOMBRE DE DIRECTIONS                                            //
+    // ================================================================== //
+
+    @Test
+    public void sixDirections() {
+        assertEquals("Il doit y avoir 6 directions", 6, Direction.values().length);
+    }
+}

--- a/src/test/java/entites/TestJoueur.java
+++ b/src/test/java/entites/TestJoueur.java
@@ -1,0 +1,162 @@
+package entites;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import batiments.Maison;
+import carte.Direction;
+import exceptions.RessourceInsuffisanteException;
+import ressources.TypeRessource;
+
+public class TestJoueur {
+
+    private Joueur joueur;
+
+    @Before
+    public void setUp() {
+        joueur = new Joueur(0, 0);
+    }
+
+    // ================================================================== //
+    //  1. INITIALISATION                                                  //
+    // ================================================================== //
+
+    @Test
+    public void init_position() {
+        assertEquals(0, joueur.getX());
+        assertEquals(0, joueur.getY());
+    }
+
+    @Test
+    public void init_orientationSud() {
+        assertEquals(Direction.SUD, joueur.getOrientation());
+    }
+
+    @Test
+    public void init_stockNonNull() {
+        assertNotNull("Le stock du joueur ne doit pas être null", joueur.getStock());
+    }
+
+    @Test
+    public void init_ouvrierListeVide() {
+        assertTrue("La liste des ouvriers doit être vide au départ",
+                joueur.getOuvriers().isEmpty());
+    }
+
+    @Test
+    public void init_batimentListeVide() {
+        assertTrue("La liste des bâtiments doit être vide au départ",
+                joueur.getBatiments().isEmpty());
+    }
+
+    // ================================================================== //
+    //  2. RESSOURCES — ajouterRessource / consommerRessource             //
+    // ================================================================== //
+
+    @Test
+    public void ajouterRessource_augmenteStock() throws Exception {
+        joueur.ajouterRessource(TypeRessource.FER, 10);
+        // On valide via consommerRessource (indirectement)
+        assertTrue(joueur.consommerRessource(TypeRessource.FER, 10));
+    }
+
+    @Test
+    public void ajouterRessource_deuxFoisCumulatif() throws Exception {
+        joueur.ajouterRessource(TypeRessource.BOIS, 5);
+        joueur.ajouterRessource(TypeRessource.BOIS, 3);
+        // 8 au total, on consomme 8
+        assertTrue(joueur.consommerRessource(TypeRessource.BOIS, 8));
+    }
+
+    @Test
+    public void consommerRessource_stockSuffisant_retourneTrue() throws Exception {
+        joueur.ajouterRessource(TypeRessource.PIERRE, 10);
+        assertTrue(joueur.consommerRessource(TypeRessource.PIERRE, 5));
+    }
+
+    @Test(expected = RessourceInsuffisanteException.class)
+    public void consommerRessource_stockInsuffisant_leveException() throws Exception {
+        joueur.consommerRessource(TypeRessource.FER, 1);
+    }
+
+    @Test(expected = RessourceInsuffisanteException.class)
+    public void consommerRessource_tropGrand_leveException() throws Exception {
+        joueur.ajouterRessource(TypeRessource.FER, 3);
+        joueur.consommerRessource(TypeRessource.FER, 5);
+    }
+
+    // ================================================================== //
+    //  3. DÉPLACEMENT                                                     //
+    // ================================================================== //
+
+    @Test
+    public void deplacer_coordonneesAbsolues() {
+        joueur.deplacer(7, 3);
+        assertEquals(7, joueur.getX());
+        assertEquals(3, joueur.getY());
+    }
+
+    @Test
+    public void deplacer_direction_NORD_decYmoins1() {
+        joueur.deplacer(Direction.NORD); // dy = -1
+        assertEquals(0, joueur.getX());
+        assertEquals(-1, joueur.getY());
+    }
+
+    @Test
+    public void deplacer_direction_EST_incXplus1() {
+        joueur.deplacer(Direction.EST); // dx = +1
+        assertEquals(1, joueur.getX());
+        assertEquals(0, joueur.getY());
+    }
+
+    @Test
+    public void deplacer_direction_metAJourOrientation() {
+        joueur.deplacer(Direction.NORD);
+        assertEquals(Direction.NORD, joueur.getOrientation());
+    }
+
+    // ================================================================== //
+    //  4. DISTANCE                                                        //
+    // ================================================================== //
+
+    @Test
+    public void distance_autreJoueur_calculCorrect() {
+        Joueur autre = new Joueur(3, 4);
+        assertEquals(5.0, joueur.distance(autre), 0.001);
+    }
+
+    @Test
+    public void distance_memePosition_zero() {
+        Joueur autre = new Joueur(0, 0);
+        assertEquals(0.0, joueur.distance(autre), 0.001);
+    }
+
+    // ================================================================== //
+    //  5. LITS DISPONIBLES                                                //
+    // ================================================================== //
+
+    @Test
+    public void getNombreLitsDisponibles_sansMaison_zero() {
+        assertEquals(0, joueur.getNombreLitsDisponibles());
+    }
+
+    @Test
+    public void getNombreLitsDisponibles_avecMaison_comptePlaces() {
+        Maison maison = new Maison("Dortoir", 0, 0, 3);
+        joueur.getBatiments().add(maison);
+        assertEquals("Une maison vide de capacité 3 doit offrir 3 lits",
+                3, joueur.getNombreLitsDisponibles());
+    }
+
+    @Test
+    public void getNombreLitsDisponibles_maisonPleine_zeroLit() {
+        Maison maison = new Maison("Dortoir", 0, 0, 2);
+        maison.loger(new Ouvrier("A", 0, 0));
+        maison.loger(new Ouvrier("B", 0, 0));
+        joueur.getBatiments().add(maison);
+        assertEquals("Une maison pleine ne doit offrir aucun lit",
+                0, joueur.getNombreLitsDisponibles());
+    }
+}

--- a/src/test/java/entites/TestOuvrier.java
+++ b/src/test/java/entites/TestOuvrier.java
@@ -1,0 +1,279 @@
+package entites;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import batiments.Batiment;
+import carte.Direction;
+import metiers.Metier;
+import ressources.Stock;
+
+public class TestOuvrier {
+
+    private Ouvrier ouvrier;
+
+    /** Métier factice neutre. */
+    private static Metier metierBidon(Role role) {
+        return new Metier() {
+            @Override public Role getType()                                          { return role; }
+            @Override public boolean peutTravaillerDans(Batiment b)                 { return false; }
+            @Override public void travailler(Ouvrier o, Batiment b, Stock s, int t) {}
+            @Override public String getNomAffichage()                               { return role.name(); }
+        };
+    }
+
+    @Before
+    public void setUp() {
+        ouvrier = new Ouvrier("Bob", 0, 0);
+    }
+
+    // ================================================================== //
+    //  1. INITIALISATION                                                  //
+    // ================================================================== //
+
+    @Test
+    public void init_etatNormal() {
+        assertEquals(EtatOuvrier.NORMAL, ouvrier.getEtat());
+    }
+
+    @Test
+    public void init_niveauDebutant() {
+        assertEquals(Ouvrier.NiveauExp.DEBUTANT, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void init_sansMetier() {
+        assertNull("L'ouvrier ne doit pas avoir de métier au départ", ouvrier.getMetier());
+    }
+
+    @Test
+    public void init_sansPoste() {
+        assertNull("L'ouvrier ne doit pas avoir de poste au départ", ouvrier.getPosteActuel());
+    }
+
+    @Test
+    public void init_moralUnite() {
+        assertEquals(1.0, ouvrier.getMoral(), 0.001);
+    }
+
+    // ================================================================== //
+    //  2. EFFICACITÉ                                                      //
+    // ================================================================== //
+
+    @Test
+    public void efficacite_debutantNormal_attendue() {
+        // DEBUTANT(0.7) × NORMAL(1.0)
+        assertEquals(0.7, ouvrier.getEfficacite(), 0.001);
+    }
+
+    @Test
+    public void efficacite_debutantFatigue_reduite() {
+        ouvrier.setEtat(EtatOuvrier.FATIGUE);
+        // 0.7 × 0.8
+        assertEquals(0.56, ouvrier.getEfficacite(), 0.001);
+    }
+
+    @Test
+    public void efficacite_debutantMotive_augmentee() {
+        ouvrier.setEtat(EtatOuvrier.MOTIVE);
+        // 0.7 × 1.2
+        assertEquals(0.84, ouvrier.getEfficacite(), 0.001);
+    }
+
+    // ================================================================== //
+    //  3. EXPÉRIENCE — travailler() et montée de niveau                  //
+    // ================================================================== //
+
+    @Test
+    public void travailler_sansMetier_aucunEffect() {
+        ouvrier.travailler(10_000);
+        assertEquals(Ouvrier.NiveauExp.DEBUTANT, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void travailler_avecMetier_progresseAuNiveauSuivant() {
+        ouvrier.setMetier(metierBidon(Role.MINEUR));
+        // Seuil DEBUTANT = 600 ticks
+        ouvrier.travailler(600);
+        assertEquals(Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void travailler_ticksInferieurSeuil_resteDebutant() {
+        ouvrier.setMetier(metierBidon(Role.MINEUR));
+        ouvrier.travailler(599);
+        assertEquals(Ouvrier.NiveauExp.DEBUTANT, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void travailler_progressionSequentielle_apprentiPuisConfirme() {
+        ouvrier.setMetier(metierBidon(Role.BUCHERON));
+        ouvrier.travailler(600);   // → APPRENTI
+        assertEquals(Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+        ouvrier.travailler(1200);  // → CONFIRME
+        assertEquals(Ouvrier.NiveauExp.CONFIRME, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void travailler_niveauMAITRE_nePasDepasser() {
+        ouvrier.setMetier(metierBidon(Role.INGENIEUR));
+        ouvrier.travailler(600);    // APPRENTI
+        ouvrier.travailler(1200);   // CONFIRME
+        ouvrier.travailler(1800);   // EXPERT
+        ouvrier.travailler(3000);   // MAITRE
+        ouvrier.travailler(999_999);// doit rester MAITRE
+        assertEquals(Ouvrier.NiveauExp.MAITRE, ouvrier.getNiveau());
+    }
+
+    // ================================================================== //
+    //  4. CHANGEMENT DE MÉTIER                                            //
+    // ================================================================== //
+
+    @Test
+    public void setMetier_changementDeType_reinitialisExperience() {
+        ouvrier.setMetier(metierBidon(Role.MINEUR));
+        ouvrier.travailler(600); // → APPRENTI
+        ouvrier.setMetier(metierBidon(Role.BUCHERON)); // autre type
+        assertEquals("Changement de type de métier : retour à DEBUTANT",
+                Ouvrier.NiveauExp.DEBUTANT, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void setMetier_memetype_conserveNiveau() {
+        ouvrier.setMetier(metierBidon(Role.MINEUR));
+        ouvrier.travailler(600); // → APPRENTI
+        ouvrier.setMetier(metierBidon(Role.MINEUR)); // même type
+        assertEquals("Même type de métier : niveau conservé",
+                Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+    }
+
+    @Test
+    public void setMetier_null_effaceMetier() {
+        ouvrier.setMetier(metierBidon(Role.MINEUR));
+        ouvrier.setMetier(null);
+        assertNull(ouvrier.getMetier());
+    }
+
+    // ================================================================== //
+    //  5. MORAL ET ÉTAT                                                   //
+    // ================================================================== //
+
+    @Test
+    public void modifierMoral_borneMax() {
+        ouvrier.modifierMoral(+5.0);
+        assertEquals(1.0, ouvrier.getMoral(), 0.001);
+    }
+
+    @Test
+    public void modifierMoral_borneMin() {
+        ouvrier.modifierMoral(-5.0);
+        assertEquals(0.0, ouvrier.getMoral(), 0.001);
+    }
+
+    @Test
+    public void mettreAJourEtat_moralEleve_tresMotive() {
+        // Moral initial = 1.0 ≥ 0.9 → TRES_MOTIVE
+        ouvrier.mettreAJourEtat();
+        assertEquals(EtatOuvrier.TRES_MOTIVE, ouvrier.getEtat());
+    }
+
+    @Test
+    public void mettreAJourEtat_moralBas_malade() {
+        ouvrier.modifierMoral(-1.0); // moral → 0.0 < 0.1
+        ouvrier.mettreAJourEtat();
+        assertEquals(EtatOuvrier.MALADE, ouvrier.getEtat());
+    }
+
+    @Test
+    public void mettreAJourEtat_moral05_normal() {
+        ouvrier.modifierMoral(-0.5); // moral → 0.5 ∈ [0.5, 0.7[
+        ouvrier.mettreAJourEtat();
+        assertEquals(EtatOuvrier.NORMAL, ouvrier.getEtat());
+    }
+
+    @Test
+    public void mettreAJourEtat_moral03_fatigue() {
+        ouvrier.modifierMoral(-0.7); // moral → 0.3 ∈ [0.3, 0.5[
+        ouvrier.mettreAJourEtat();
+        assertEquals(EtatOuvrier.FATIGUE, ouvrier.getEtat());
+    }
+
+    // ================================================================== //
+    //  6. BESOINS VITAUX                                                  //
+    // ================================================================== //
+
+    @Test
+    public void signalerManqueNourriture_degradeMoral() {
+        double moralAvant = ouvrier.getMoral();
+        ouvrier.signalerManqueNourriture();
+        assertTrue("Un manque de nourriture doit baisser le moral",
+                ouvrier.getMoral() < moralAvant);
+    }
+
+    @Test
+    public void signalerManqueEau_degradeMoral() {
+        double moralAvant = ouvrier.getMoral();
+        ouvrier.signalerManqueEau();
+        assertTrue("Un manque d'eau doit baisser le moral",
+                ouvrier.getMoral() < moralAvant);
+    }
+
+    @Test
+    public void setAMangeEtBu_reinitialiseFaimEtSoif() {
+        ouvrier.signalerManqueNourriture();
+        ouvrier.signalerManqueEau();
+        ouvrier.setAMangeEtBu(true);
+        assertEquals(0.0, ouvrier.getFaim(), 0.001);
+        assertEquals(0.0, ouvrier.getSoif(), 0.001);
+    }
+
+    @Test
+    public void recupererNuit_augmenteMoral() {
+        ouvrier.modifierMoral(-0.5); // moral → 0.5
+        double moralAvant = ouvrier.getMoral();
+        ouvrier.recupererNuit();
+        assertTrue("La nuit améliore le moral", ouvrier.getMoral() > moralAvant);
+    }
+
+    // ================================================================== //
+    //  7. DÉPLACEMENT                                                     //
+    // ================================================================== //
+
+    @Test
+    public void deplacer_coordonneesAbsolues() {
+        ouvrier.deplacer(5, 8);
+        assertEquals(5, ouvrier.getX());
+        assertEquals(8, ouvrier.getY());
+    }
+
+    @Test
+    public void deplacer_direction_EST() {
+        ouvrier.deplacer(Direction.EST); // dx=+1
+        assertEquals(1, ouvrier.getX());
+        assertEquals(0, ouvrier.getY());
+    }
+
+    @Test
+    public void deplacer_direction_SUD() {
+        ouvrier.deplacer(Direction.SUD); // dy=+1
+        assertEquals(0, ouvrier.getX());
+        assertEquals(1, ouvrier.getY());
+    }
+
+    // ================================================================== //
+    //  8. DISTANCE                                                        //
+    // ================================================================== //
+
+    @Test
+    public void distance_memePosition_zero() {
+        Ouvrier autre = new Ouvrier("Alice", 0, 0);
+        assertEquals(0.0, ouvrier.distance(autre), 0.001);
+    }
+
+    @Test
+    public void distance_pythagoricienne_3_4_5() {
+        Ouvrier autre = new Ouvrier("Alice", 3, 4);
+        assertEquals(5.0, ouvrier.distance(autre), 0.001);
+    }
+}

--- a/src/test/java/metiers/TestBucheron.java
+++ b/src/test/java/metiers/TestBucheron.java
@@ -1,0 +1,135 @@
+package metiers;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import batiments.Batiment;
+import batiments.LieuDeRessource;
+import batiments.TypeBatiment;
+import carte.Direction;
+import carte.Item;
+import entites.Ouvrier;
+import entites.Role;
+import exceptions.StockException;
+import ressources.Stock;
+import ressources.TypeRessource;
+
+public class TestBucheron {
+
+    private Bucheron bucheron;
+    private Ouvrier ouvrier;
+    private Stock stock;
+
+    /** Bâtiment stub simple. */
+    private static Batiment batimentStub(TypeBatiment type, boolean operationnel) {
+        return new Batiment() {
+            @Override public TypeBatiment getType()                    { return type; }
+            @Override public boolean isOperationnel()                  { return operationnel; }
+            @Override public void affecterPersonnel(Ouvrier o)         {}
+            @Override public void retirerPersonnel(Ouvrier o)          {}
+            @Override public boolean aDeLaPlace()                      { return true; }
+            @Override public void mettreAJour(Stock s, int t)          {}
+            @Override public int getX()                                { return 0; }
+            @Override public int getY()                                { return 0; }
+            @Override public void deplacer(int x, int y)               {}
+            @Override public void deplacer(Direction d)                {}
+            @Override public double distance(Item autre)               { return 0; }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        bucheron = new Bucheron();
+        ouvrier  = new Ouvrier("Gaston", 0, 0);
+        ouvrier.setMetier(bucheron);
+        stock = new Stock(false);
+    }
+
+    // ================================================================== //
+    //  1. IDENTITÉ DU MÉTIER                                              //
+    // ================================================================== //
+
+    @Test
+    public void getType_retourneBUCHERON() {
+        assertEquals(Role.BUCHERON, bucheron.getType());
+    }
+
+    @Test
+    public void getNomAffichage_nonVide() {
+        assertNotNull(bucheron.getNomAffichage());
+        assertFalse(bucheron.getNomAffichage().isEmpty());
+    }
+
+    // ================================================================== //
+    //  2. peutTravaillerDans                                              //
+    // ================================================================== //
+
+    @Test
+    public void peutTravaillerDans_foret_retourneTrue() {
+        assertTrue(bucheron.peutTravaillerDans(batimentStub(TypeBatiment.FORET, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_mine_retourneFalse() {
+        assertFalse(bucheron.peutTravaillerDans(batimentStub(TypeBatiment.MINE, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_usine_retourneFalse() {
+        assertFalse(bucheron.peutTravaillerDans(batimentStub(TypeBatiment.USINE, true)));
+    }
+
+    // ================================================================== //
+    //  3. PRODUCTION DE BOIS                                              //
+    // ================================================================== //
+
+    @Test
+    public void travailler_cadence5ticks_produitBois() throws Exception {
+        Batiment foret = batimentStub(TypeBatiment.FORET, true);
+        // CADENCE = 5 ticks ; efficacité DEBUTANT/NORMAL = 0.7 → 5/0.7 ≈ 7.14 ticks réels
+        // On envoie 8 ticks : 8 × 0.7 = 5.6 ticks efficaces → 1 bois produit
+        bucheron.travailler(ouvrier, foret, stock, 8);
+        assertEquals("Un bois doit être produit après ~8 ticks réels",
+                1, stock.getQuantite(TypeRessource.BOIS));
+    }
+
+    @Test
+    public void travailler_pasAssezDeTicks_rienProduit() throws Exception {
+        Batiment foret = batimentStub(TypeBatiment.FORET, true);
+        // 3 ticks réels × 0.7 = 2.1 efficaces < 5 → rien
+        bucheron.travailler(ouvrier, foret, stock, 3);
+        assertEquals(0, stock.getQuantite(TypeRessource.BOIS));
+    }
+
+    @Test
+    public void travailler_batimentInoperant_rienProduit() throws Exception {
+        Batiment foretBrule = batimentStub(TypeBatiment.FORET, false);
+        bucheron.travailler(ouvrier, foretBrule, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.BOIS));
+    }
+
+    @Test
+    public void travailler_mauvaisBatiment_rienProduit() throws Exception {
+        Batiment mine = batimentStub(TypeBatiment.MINE, true);
+        bucheron.travailler(ouvrier, mine, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.BOIS));
+    }
+
+    @Test
+    public void travailler_ticksAccumules_plusieursBois() throws Exception {
+        Batiment foret = batimentStub(TypeBatiment.FORET, true);
+        // 100 ticks × 0.7 = 70 efficaces → 70/5 = 14 bois
+        bucheron.travailler(ouvrier, foret, stock, 100);
+        assertEquals("100 ticks à efficacité 0.7 doivent produire 14 bois",
+                14, stock.getQuantite(TypeRessource.BOIS));
+    }
+
+    @Test
+    public void travailler_faisProgresserExperience() throws Exception {
+        Batiment foret = batimentStub(TypeBatiment.FORET, true);
+        bucheron.travailler(ouvrier, foret, stock, 600);
+        assertEquals("L'ouvrier doit progresser au-delà de DEBUTANT après 600 ticks",
+                Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+    }
+}

--- a/src/test/java/metiers/TestIngenieur.java
+++ b/src/test/java/metiers/TestIngenieur.java
@@ -1,0 +1,158 @@
+package metiers;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import batiments.Batiment;
+import batiments.TypeBatiment;
+import carte.Direction;
+import carte.Item;
+import entites.Ouvrier;
+import entites.Role;
+import ressources.Stock;
+import ressources.TypeRessource;
+
+public class TestIngenieur {
+
+    private Ingenieur ingenieur;
+    private Ouvrier ouvrier;
+    private Stock stock;
+
+    private static Batiment batimentStub(TypeBatiment type, boolean operationnel) {
+        return new Batiment() {
+            @Override public TypeBatiment getType()                    { return type; }
+            @Override public boolean isOperationnel()                  { return operationnel; }
+            @Override public void affecterPersonnel(Ouvrier o)         {}
+            @Override public void retirerPersonnel(Ouvrier o)          {}
+            @Override public boolean aDeLaPlace()                      { return true; }
+            @Override public void mettreAJour(Stock s, int t)          {}
+            @Override public int getX()                                { return 0; }
+            @Override public int getY()                                { return 0; }
+            @Override public void deplacer(int x, int y)               {}
+            @Override public void deplacer(Direction d)                {}
+            @Override public double distance(Item autre)               { return 0; }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        ingenieur = new Ingenieur();
+        ouvrier   = new Ouvrier("Curie", 0, 0);
+        ouvrier.setMetier(ingenieur);
+        stock     = new Stock(false);
+    }
+
+    // ================================================================== //
+    //  1. IDENTITÉ DU MÉTIER                                              //
+    // ================================================================== //
+
+    @Test
+    public void getType_retourneINGENIEUR() {
+        assertEquals(Role.INGENIEUR, ingenieur.getType());
+    }
+
+    @Test
+    public void peutTravaillerDans_usineElectronique_retourneTrue() {
+        assertTrue(ingenieur.peutTravaillerDans(
+                batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_fonderie_retourneFalse() {
+        assertFalse(ingenieur.peutTravaillerDans(
+                batimentStub(TypeBatiment.FONDERIE, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_foret_retourneFalse() {
+        assertFalse(ingenieur.peutTravaillerDans(
+                batimentStub(TypeBatiment.FORET, true)));
+    }
+
+    // ================================================================== //
+    //  2. PRODUCTION DE PROCESSEUR_VOL (2 CARTE_MERE + 1 ALLIAGE, 600t) //
+    // ================================================================== //
+
+    @Test
+    public void travailler_sansRessources_rienProduit() throws Exception {
+        Batiment usine = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true);
+        ingenieur.travailler(ouvrier, usine, stock, 10_000);
+        assertEquals(0, stock.getQuantite(TypeRessource.PROCESSEUR_VOL));
+    }
+
+    @Test
+    public void travailler_seulementCartes_rienProduit() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        Batiment usine = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true);
+        ingenieur.travailler(ouvrier, usine, stock, 10_000);
+        assertEquals("Sans ALLIAGE_THERMIQUE, pas de PROCESSEUR_VOL",
+                0, stock.getQuantite(TypeRessource.PROCESSEUR_VOL));
+    }
+
+    @Test
+    public void travailler_ressourcesCompletes_consommeIngredients() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        stock.ajouter(TypeRessource.ALLIAGE_THERMIQUE, 1);
+        Batiment usine = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true);
+        // Juste le démarrage du cycle
+        ingenieur.travailler(ouvrier, usine, stock, 5);
+        assertEquals("2 CARTE_MERE doivent être consommées au démarrage",
+                0, stock.getQuantite(TypeRessource.CARTE_MERE));
+        assertEquals("1 ALLIAGE doit être consommé au démarrage",
+                0, stock.getQuantite(TypeRessource.ALLIAGE_THERMIQUE));
+    }
+
+    @Test
+    public void travailler_cycleComplet_produitProcesseur() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        stock.ajouter(TypeRessource.ALLIAGE_THERMIQUE, 1);
+        Batiment usine = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true);
+        // 600 ticks / 0.7 efficacité ≈ 857 ticks réels
+        ingenieur.travailler(ouvrier, usine, stock, 870);
+        assertEquals("Un cycle complet doit livrer 1 PROCESSEUR_VOL",
+                1, stock.getQuantite(TypeRessource.PROCESSEUR_VOL));
+    }
+
+    @Test
+    public void travailler_cycleIncomplet_pasDeProcesseur() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        stock.ajouter(TypeRessource.ALLIAGE_THERMIQUE, 1);
+        Batiment usine = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true);
+        // Seulement 100 ticks → 100 × 0.7 = 70 efficaces < 600
+        ingenieur.travailler(ouvrier, usine, stock, 100);
+        assertEquals(0, stock.getQuantite(TypeRessource.PROCESSEUR_VOL));
+    }
+
+    @Test
+    public void travailler_batimentInoperant_rienProduit() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        stock.ajouter(TypeRessource.ALLIAGE_THERMIQUE, 1);
+        Batiment inoperant = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, false);
+        ingenieur.travailler(ouvrier, inoperant, stock, 10_000);
+        assertEquals(0, stock.getQuantite(TypeRessource.PROCESSEUR_VOL));
+    }
+
+    @Test
+    public void travailler_mauvaisBatiment_rienProduit() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        stock.ajouter(TypeRessource.ALLIAGE_THERMIQUE, 1);
+        Batiment usineElec = batimentStub(TypeBatiment.FONDERIE, true);
+        ingenieur.travailler(ouvrier, usineElec, stock, 10_000);
+        assertEquals(0, stock.getQuantite(TypeRessource.PROCESSEUR_VOL));
+    }
+
+    // ================================================================== //
+    //  3. EXPÉRIENCE                                                      //
+    // ================================================================== //
+
+    @Test
+    public void travailler_faisProgresserExperience() throws Exception {
+        stock.ajouter(TypeRessource.CARTE_MERE, 2);
+        stock.ajouter(TypeRessource.ALLIAGE_THERMIQUE, 1);
+        Batiment usine = batimentStub(TypeBatiment.USINE_ELECTRONIQUE, true);
+        ingenieur.travailler(ouvrier, usine, stock, 600);
+        assertEquals("L'ouvrier doit progresser après 600 ticks",
+                Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+    }
+}

--- a/src/test/java/metiers/TestMacon.java
+++ b/src/test/java/metiers/TestMacon.java
@@ -1,0 +1,141 @@
+package metiers;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import batiments.Batiment;
+import batiments.TypeBatiment;
+import carte.Direction;
+import carte.Item;
+import entites.Ouvrier;
+import entites.Role;
+import ressources.Stock;
+import ressources.TypeRessource;
+
+public class TestMacon {
+
+    private Macon macon;
+    private Ouvrier ouvrier;
+    private Stock stock;
+
+    private static Batiment batimentStub(TypeBatiment type, boolean operationnel) {
+        return new Batiment() {
+            @Override public TypeBatiment getType()                    { return type; }
+            @Override public boolean isOperationnel()                  { return operationnel; }
+            @Override public void affecterPersonnel(Ouvrier o)         {}
+            @Override public void retirerPersonnel(Ouvrier o)          {}
+            @Override public boolean aDeLaPlace()                      { return true; }
+            @Override public void mettreAJour(Stock s, int t)          {}
+            @Override public int getX()                                { return 0; }
+            @Override public int getY()                                { return 0; }
+            @Override public void deplacer(int x, int y)               {}
+            @Override public void deplacer(Direction d)                {}
+            @Override public double distance(Item autre)               { return 0; }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        macon   = new Macon();
+        ouvrier = new Ouvrier("Pierre", 0, 0);
+        ouvrier.setMetier(macon);
+        stock   = new Stock(false);
+    }
+
+    // ================================================================== //
+    //  1. IDENTITÉ DU MÉTIER                                              //
+    // ================================================================== //
+
+    @Test
+    public void getType_retourneMASON() {
+        assertEquals(Role.MACON, macon.getType());
+    }
+
+    @Test
+    public void peutTravaillerDans_menuiserie_retourneTrue() {
+        assertTrue(macon.peutTravaillerDans(batimentStub(TypeBatiment.MENUISERIE, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_fonderie_retourneFalse() {
+        assertFalse(macon.peutTravaillerDans(batimentStub(TypeBatiment.FONDERIE, true)));
+    }
+
+    // ================================================================== //
+    //  2. CYCLE DE PRODUCTION                                             //
+    // ================================================================== //
+
+    @Test
+    public void travailler_sansRessources_rienProduit() throws Exception {
+        Batiment menuiserie = batimentStub(TypeBatiment.MENUISERIE, true);
+        // Pas de bois → cycle impossible
+        macon.travailler(ouvrier, menuiserie, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.POUTRE));
+    }
+
+    @Test
+    public void travailler_cycleComplet_produitUnePoutre() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 10); // recette = 10 BOIS → 1 POUTRE
+        Batiment menuiserie = batimentStub(TypeBatiment.MENUISERIE, true);
+        // TICKS_PRODUCTION = 60, efficacité DEBUTANT/NORMAL = 0.7
+        // ticks nécessaires ≈ 60 / 0.7 ≈ 86 ticks réels
+        macon.travailler(ouvrier, menuiserie, stock, 90);
+        assertEquals("Un cycle complet doit produire 1 poutre",
+                1, stock.getQuantite(TypeRessource.POUTRE));
+    }
+
+    @Test
+    public void travailler_boisConsommeAuDemarrage() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 10);
+        Batiment menuiserie = batimentStub(TypeBatiment.MENUISERIE, true);
+        // On démarre le cycle mais pas encore terminé
+        macon.travailler(ouvrier, menuiserie, stock, 5);
+        assertEquals("Les 10 bois doivent être consommés dès le démarrage du cycle",
+                0, stock.getQuantite(TypeRessource.BOIS));
+    }
+
+    @Test
+    public void travailler_cycleIncomplet_pasDePoutre() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 10);
+        Batiment menuiserie = batimentStub(TypeBatiment.MENUISERIE, true);
+        // Seulement 10 ticks → 10 × 0.7 = 7 efficaces < 60
+        macon.travailler(ouvrier, menuiserie, stock, 10);
+        assertEquals(0, stock.getQuantite(TypeRessource.POUTRE));
+    }
+
+    @Test
+    public void travailler_deuxCycles_deuxPoutres() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 20);
+        Batiment menuiserie = batimentStub(TypeBatiment.MENUISERIE, true);
+        // 90 ticks suffit pour 1 cycle; on fait 2×90 pour 2 cycles
+        macon.travailler(ouvrier, menuiserie, stock, 90); // cycle 1
+        macon.travailler(ouvrier, menuiserie, stock, 90); // cycle 2
+        assertEquals(2, stock.getQuantite(TypeRessource.POUTRE));
+    }
+
+    @Test
+    public void travailler_batimentInoperant_rienProduit() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 10);
+        Batiment inoperant = batimentStub(TypeBatiment.MENUISERIE, false);
+        macon.travailler(ouvrier, inoperant, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.POUTRE));
+    }
+
+    @Test
+    public void travailler_mauvaisBatiment_rienProduit() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 10);
+        Batiment foret = batimentStub(TypeBatiment.FORET, true);
+        macon.travailler(ouvrier, foret, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.POUTRE));
+    }
+
+    @Test
+    public void travailler_faisProgresserExperience() throws Exception {
+        stock.ajouter(TypeRessource.BOIS, 10);
+        Batiment menuiserie = batimentStub(TypeBatiment.MENUISERIE, true);
+        macon.travailler(ouvrier, menuiserie, stock, 600);
+        assertEquals("L'ouvrier doit progresser après 600 ticks",
+                Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+    }
+}

--- a/src/test/java/metiers/TestTechnicien.java
+++ b/src/test/java/metiers/TestTechnicien.java
@@ -1,0 +1,184 @@
+package metiers;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+import batiments.Batiment;
+import batiments.TypeBatiment;
+import carte.Direction;
+import carte.Item;
+import entites.Ouvrier;
+import entites.Role;
+import ressources.Stock;
+import ressources.TypeRessource;
+
+public class TestTechnicien {
+
+    private Technicien technicien;
+    private Ouvrier ouvrier;
+    private Stock stock;
+
+    private static Batiment batimentStub(TypeBatiment type, boolean operationnel) {
+        return new Batiment() {
+            @Override public TypeBatiment getType()                    { return type; }
+            @Override public boolean isOperationnel()                  { return operationnel; }
+            @Override public void affecterPersonnel(Ouvrier o)         {}
+            @Override public void retirerPersonnel(Ouvrier o)          {}
+            @Override public boolean aDeLaPlace()                      { return true; }
+            @Override public void mettreAJour(Stock s, int t)          {}
+            @Override public int getX()                                { return 0; }
+            @Override public int getY()                                { return 0; }
+            @Override public void deplacer(int x, int y)               {}
+            @Override public void deplacer(Direction d)                {}
+            @Override public double distance(Item autre)               { return 0; }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        technicien = new Technicien();
+        ouvrier    = new Ouvrier("Lena", 0, 0);
+        ouvrier.setMetier(technicien);
+        stock      = new Stock(false);
+    }
+
+    // ================================================================== //
+    //  1. IDENTITÉ DU MÉTIER                                              //
+    // ================================================================== //
+
+    @Test
+    public void getType_retourneTECHNICIEN() {
+        assertEquals(Role.TECHNICIEN, technicien.getType());
+    }
+
+    @Test
+    public void peutTravaillerDans_fonderie_retourneTrue() {
+        assertTrue(technicien.peutTravaillerDans(batimentStub(TypeBatiment.FONDERIE, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_raffinerie_retourneTrue() {
+        assertTrue(technicien.peutTravaillerDans(batimentStub(TypeBatiment.RAFFINERIE, true)));
+    }
+
+    @Test
+    public void peutTravaillerDans_foret_retourneFalse() {
+        assertFalse(technicien.peutTravaillerDans(batimentStub(TypeBatiment.FORET, true)));
+    }
+
+    // ================================================================== //
+    //  2. FONDERIE — PLAQUE_ACIER (10 MINERAI_FER → 1 PLAQUE, 120 ticks) //
+    // ================================================================== //
+
+    @Test
+    public void fonderie_sansRessources_rienProduit() throws Exception {
+        Batiment fonderie = batimentStub(TypeBatiment.FONDERIE, true);
+        technicien.travailler(ouvrier, fonderie, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.PLAQUE_ACIER));
+    }
+
+    @Test
+    public void fonderie_cycleComplet_produitPlaqueAcier() throws Exception {
+        stock.ajouter(TypeRessource.MINERAI_FER, 10);
+        Batiment fonderie = batimentStub(TypeBatiment.FONDERIE, true);
+        // 120 ticks / 0.7 efficacité ≈ 172 ticks réels
+        technicien.travailler(ouvrier, fonderie, stock, 175);
+        assertEquals("Un cycle fonderie complet doit livrer 1 PLAQUE_ACIER",
+                1, stock.getQuantite(TypeRessource.PLAQUE_ACIER));
+    }
+
+    @Test
+    public void fonderie_mineralConsommeAuDemarrage() throws Exception {
+        stock.ajouter(TypeRessource.MINERAI_FER, 10);
+        Batiment fonderie = batimentStub(TypeBatiment.FONDERIE, true);
+        technicien.travailler(ouvrier, fonderie, stock, 5);
+        assertEquals("10 MINERAI_FER doivent être consommés dès le démarrage",
+                0, stock.getQuantite(TypeRessource.MINERAI_FER));
+    }
+
+    @Test
+    public void fonderie_cycleIncomplet_pasDePlaque() throws Exception {
+        stock.ajouter(TypeRessource.MINERAI_FER, 10);
+        Batiment fonderie = batimentStub(TypeBatiment.FONDERIE, true);
+        technicien.travailler(ouvrier, fonderie, stock, 10);
+        assertEquals(0, stock.getQuantite(TypeRessource.PLAQUE_ACIER));
+    }
+
+    // ================================================================== //
+    //  3. RAFFINERIE — KEROSENE (10 PETROLE → 1 KEROSENE, 180 ticks)     //
+    // ================================================================== //
+
+    @Test
+    public void raffinerie_kerosene_cycleComplet() throws Exception {
+        stock.ajouter(TypeRessource.PETROLE, 10);
+        Batiment raffinerie = batimentStub(TypeBatiment.RAFFINERIE, true);
+        // 180 / 0.7 ≈ 257 ticks réels
+        technicien.travailler(ouvrier, raffinerie, stock, 260);
+        assertEquals("Un cycle raffinerie doit produire 1 KEROSENE",
+                1, stock.getQuantite(TypeRessource.KEROSENE));
+    }
+
+    @Test
+    public void raffinerie_kerosene_petrolConsomme() throws Exception {
+        stock.ajouter(TypeRessource.PETROLE, 10);
+        Batiment raffinerie = batimentStub(TypeBatiment.RAFFINERIE, true);
+        technicien.travailler(ouvrier, raffinerie, stock, 5);
+        assertEquals("10 PETROLE doivent être consommés dès le démarrage",
+                0, stock.getQuantite(TypeRessource.PETROLE));
+    }
+
+    // ================================================================== //
+    //  4. RAFFINERIE — PLASTIQUE (5 PETROLE → 1 PLASTIQUE, 120 ticks)    //
+    // ================================================================== //
+
+    @Test
+    public void raffinerie_plastique_seulement5petrole() throws Exception {
+        stock.ajouter(TypeRessource.PETROLE, 5); // moins que pour kérosène
+        Batiment raffinerie = batimentStub(TypeBatiment.RAFFINERIE, true);
+        // 120 / 0.7 ≈ 172 ticks
+        technicien.travailler(ouvrier, raffinerie, stock, 175);
+        assertEquals("Avec 5 PETROLE, 1 PLASTIQUE doit être produit",
+                1, stock.getQuantite(TypeRessource.PLASTIQUE));
+    }
+
+    // ================================================================== //
+    //  5. PRIORITÉ EN RAFFINERIE                                          //
+    // ================================================================== //
+
+    @Test
+    public void raffinerie_priorite_keroseneAvantPlastique() throws Exception {
+        // Assez pour kérosène (10) ET plastique (5) → kérosène prioritaire
+        stock.ajouter(TypeRessource.PETROLE, 15);
+        Batiment raffinerie = batimentStub(TypeBatiment.RAFFINERIE, true);
+        technicien.travailler(ouvrier, raffinerie, stock, 5); // démarre un cycle
+        // Après démarrage, 10 pétrolont été consommés (kérosène, pas 5 plastique)
+        assertEquals("Le kérosène est prioritaire : 10 pétrolont être consommés",
+                5, stock.getQuantite(TypeRessource.PETROLE));
+    }
+
+    // ================================================================== //
+    //  6. BATIMENT INOPERANT                                              //
+    // ================================================================== //
+
+    @Test
+    public void travailler_batimentInoperant_rienProduit() throws Exception {
+        stock.ajouter(TypeRessource.MINERAI_FER, 10);
+        Batiment inoperant = batimentStub(TypeBatiment.FONDERIE, false);
+        technicien.travailler(ouvrier, inoperant, stock, 1000);
+        assertEquals(0, stock.getQuantite(TypeRessource.PLAQUE_ACIER));
+    }
+
+    // ================================================================== //
+    //  7. EXPÉRIENCE                                                      //
+    // ================================================================== //
+
+    @Test
+    public void travailler_faisProgresserExperience() throws Exception {
+        stock.ajouter(TypeRessource.MINERAI_FER, 10);
+        Batiment fonderie = batimentStub(TypeBatiment.FONDERIE, true);
+        technicien.travailler(ouvrier, fonderie, stock, 600);
+        assertEquals("L'ouvrier doit progresser après 600 ticks",
+                Ouvrier.NiveauExp.APPRENTI, ouvrier.getNiveau());
+    }
+}


### PR DESCRIPTION
Ajout des tests  pour les packages non couverts.


- batiments : TestEcole, TestSerre, TestStationPompage
- entites   : TestOuvrier, TestJoueur
- metiers   : TestBucheron, TestMacon, TestTechnicien, TestIngenieur
- carte     : TestCase, TestDirection

 270 tests au total